### PR TITLE
New forward L4D2_OnChooseVictim

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -49,6 +49,7 @@ detourFiles = [
 	'detours/get_mission_versus_boss_spawning.cpp', 
     'detours/cthrow_activate_ability.cpp', 
 	'detours/start_melee_swing.cpp',
+	'detours/choose_victim.cpp',
 ]
 
 l4d2sdkFiles = [

--- a/Readme.mkd
+++ b/Readme.mkd
@@ -35,3 +35,7 @@
 * New native: `L4D_ReplaceTank(tank, newtank)` -- call `ZombieManager::ReplaceTank(CTerrorPlayer *,CTerrorPlayer *)`.
 * Fixed GameRules on Sourcemod >= 1.7.
 * Disabled `L4D2_OnSpitSpread` and `L4D2_OnPounceOrLeapStumble` to prevent crashes.
+
+###September 02, 2017 :: 0.6.2###
+* New forward : `L4D2_OnChooseVictim(specialInfeted, &curTarget)` -- called whenever `BossZombiePlayer(CTerrorPlayer *, int, CBaseEntity *)` is invoked. This is called in a think hook from within the game so make sure you don't do to much code in it
+* Made includes compatiable with sourcemods transitional syntax

--- a/Readme.mkd
+++ b/Readme.mkd
@@ -37,5 +37,5 @@
 * Disabled `L4D2_OnSpitSpread` and `L4D2_OnPounceOrLeapStumble` to prevent crashes.
 
 ###September 02, 2017 :: 0.6.2###
-* New forward : `L4D2_OnChooseVictim(specialInfeted, &curTarget)` -- called whenever `BossZombiePlayer(CTerrorPlayer *, int, CBaseEntity *)` is invoked. This is called in a think hook from within the game so make sure you don't do to much code in it
+* New forward : `L4D2_OnChooseVictim(specialInfected, &curTarget)` -- called whenever `BossZombiePlayer(CTerrorPlayer *, int, CBaseEntity *)` is invoked. This is called in a think hook from within the game so make sure you don't do to much code in it
 * Made includes compatiable with sourcemods transitional syntax

--- a/detours/choose_victim.cpp
+++ b/detours/choose_victim.cpp
@@ -1,0 +1,69 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * Left 4 Downtown SourceMod Extension
+ * Copyright (C) 2010 Michael "ProdigySim" Busby
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#include "choose_victim.h"
+#include "extension.h"
+
+namespace Detours
+{
+	CBaseEntity* BossZombiePlayerBotChooseVictim::BossZombiePlayerBotChooseVictimActivate(CBaseEntity* pCurTarget, int i1, CBaseEntity* pEnt)
+	{
+		cell_t result = Pl_Continue;
+		int curTarget = gamehelpers->EntityToBCompatRef(pCurTarget);
+		if(g_pFwdOnChooseVictim)
+		{
+			edict_t *pZombieBoss = gameents->BaseEntityToEdict(reinterpret_cast<CBaseEntity*>(this));
+			int specialInfected = IndexOfEdict(pZombieBoss);
+			
+			L4D_DEBUG_LOG("L4D2_ChooseVictim(%d, %d) forward has been sent out", specialInfected, gamehelpers->EntityToBCompatRef(pCurTarget));
+
+			g_pFwdOnChooseVictim->PushCell(specialInfected);
+			g_pFwdOnChooseVictim->PushCellByRef(&curTarget);
+			g_pFwdOnChooseVictim->Execute(&result);
+		}
+		
+		if(result == Pl_Handled)
+		{
+			if(curTarget <= 0)
+				return (this->*(GetTrampoline()))(pCurTarget, i1, pEnt);
+			else
+			{
+				CBaseEntity *pNewTarget = gamehelpers->ReferenceToEntity(curTarget);
+				return pNewTarget;
+			}
+		}
+		else
+		{
+			
+			return (this->*(GetTrampoline()))(pCurTarget, i1, pEnt);
+		}
+	}
+};

--- a/detours/choose_victim.h
+++ b/detours/choose_victim.h
@@ -1,0 +1,63 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * Left 4 Downtown SourceMod Extension
+ * Copyright (C) 2010 Michael "ProdigySim" Busby
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#ifndef _INCLUDE_SOURCEMOD_DETOUR_BOSSZOMBIEPLAYERBOTCHOOSEVICTIM_H_
+#define _INCLUDE_SOURCEMOD_DETOUR_BOSSZOMBIEPLAYERBOTCHOOSEVICTIM_H_
+
+#include "detour_template.h"
+
+namespace Detours 
+{
+
+	class BossZombiePlayerBotChooseVictim;
+	typedef CBaseEntity* (BossZombiePlayerBotChooseVictim::*BossZombiePlayerBotChooseVictimFunc)(CBaseEntity *, int, CBaseEntity *);
+
+	class BossZombiePlayerBotChooseVictim : public DetourTemplate<BossZombiePlayerBotChooseVictimFunc, BossZombiePlayerBotChooseVictim>
+	{
+		private: //note: implementation of DetourTemplate abstracts
+
+			CBaseEntity *BossZombiePlayerBotChooseVictimActivate(CBaseEntity *, int, CBaseEntity *);
+
+			// get the signature name (i.e. "BossZombiePlayerBotChooseVictim") from the game conf
+			virtual const char *GetSignatureName()
+			{
+				return "BossZombiePlayerBotChooseVictim";
+			}
+
+			//notify our patch system which function should be used as the detour
+			virtual BossZombiePlayerBotChooseVictimFunc GetDetour()
+			{
+				return &BossZombiePlayerBotChooseVictim::BossZombiePlayerBotChooseVictimActivate;
+			}
+	};
+
+};
+#endif

--- a/extension.cpp
+++ b/extension.cpp
@@ -84,6 +84,7 @@
 #include "detours/on_stagger.h"
 #include "detours/terror_weapon_hit.h"
 #include "detours/get_mission_info.h"
+#include "detours/choose_victim.h"
 //#include "detours/inferno_spread.h"
 //#include "detours/shoved_by_pounce_landing.h"
 
@@ -139,6 +140,7 @@ IForward *g_pFwdOnTerrorWeaponHit = NULL;
 IForward *g_pFwdAddonsDisabler = NULL;
 IForward *g_pFwdInfernoSpread = NULL;
 IForward *g_pFwdOnShovedByPounceLanding = NULL;
+IForward *g_pFwdOnChooseVictim = NULL;
 
 bool g_bRoundEnd = false;
 
@@ -237,6 +239,7 @@ bool Left4Downtown::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	g_pFwdAddonsDisabler = forwards->CreateForward("L4D2_OnClientDisableAddons", ET_Event, 1, /*types*/NULL, Param_String);
 	g_pFwdInfernoSpread = forwards->CreateForward("L4D2_OnSpitSpread", ET_Event, 5, /*types*/NULL, Param_Cell, Param_Cell, Param_FloatByRef, Param_FloatByRef, Param_FloatByRef);
 	g_pFwdOnShovedByPounceLanding = forwards->CreateForward("L4D2_OnPounceOrLeapStumble", ET_Event, 2, /*types*/NULL, Param_Cell, Param_Cell);
+	g_pFwdOnChooseVictim = forwards->CreateForward("L4D2_OnChooseVictim", ET_Event, 2, /*types*/ NULL, Param_Cell, Param_CellByRef);
 
 	playerhelpers->AddClientListener(&g_Left4DowntownTools);
 	playerhelpers->RegisterCommandTargetProcessor(&g_Left4DowntownTools);
@@ -332,6 +335,7 @@ void Left4Downtown::SDK_OnAllLoaded()
 	g_PatchManager.Register(new AutoPatch<Detours::FastGetSurvivorSet>());
 	g_PatchManager.Register(new AutoPatch<Detours::GetMissionVersusBossSpawning>());
 	g_PatchManager.Register(new AutoPatch<Detours::CThrowActivate>());
+	g_PatchManager.Register(new AutoPatch<Detours::BossZombiePlayerBotChooseVictim>());
 	g_PatchManager.Register(new AutoPatch<Detours::StartMeleeSwing>());
 	g_PatchManager.Register(new AutoPatch<Detours::ReplaceTank>());
 	g_PatchManager.Register(new AutoPatch<Detours::UseHealingItems>());
@@ -414,6 +418,7 @@ void Left4Downtown::SDK_OnUnload()
     forwards->ReleaseForward(g_pFwdAddonsDisabler);
     forwards->ReleaseForward(g_pFwdInfernoSpread);
     forwards->ReleaseForward(g_pFwdOnShovedByPounceLanding);
+	forwards->ReleaseForward(g_pFwdOnChooseVictim);
 }
 
 class BaseAccessor : public IConCommandBaseAccessor

--- a/extension.h
+++ b/extension.h
@@ -180,6 +180,7 @@ extern IForward *g_pFwdOnTerrorWeaponHit;
 extern IForward *g_pFwdAddonsDisabler;
 extern IForward *g_pFwdInfernoSpread;
 extern IForward *g_pFwdOnShovedByPounceLanding;
+extern IForward *g_pFwdOnChooseVictim;
 
 extern bool g_bRoundEnd;
 

--- a/gamedata/left4downtown.l4d2.txt
+++ b/gamedata/left4downtown.l4d2.txt
@@ -219,7 +219,18 @@
                 /* 55 8B EC 81 EC ? ? ? ? A1 ? ? ? ? 33 C5 89 45 FC 53 56 8D 85 */
 
             }
-           
+			
+			/*
+			* BossZombiePlayerBot::ChooseVictim(CTerrorPlayer *, int, CBaseCombatCharacter *)
+			* Unique String: switching to directly visible victim\n
+			*/
+            "BossZombiePlayerBotChooseVictim"
+			{
+				"library"	"server"
+				"linux"		"@_ZN19BossZombiePlayerBot12ChooseVictimEP13CTerrorPlayeriP20CBaseCombatCharacter"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x24\xA1\x2A\x2A\x2A\x2A\x83\x78\x30\x00\x53"
+				/* 55 8B EC 83 EC 24 A1 ? ? ? ? 83 78 30 00 53 */
+			}
             /*
              * SurvivorBot::SetHumanSpectator(CTerrorPlayer*)
              * Very similar to BossZombiePlayerBot::SetHumanSpectator()

--- a/scripting/include/l4d2director.inc
+++ b/scripting/include/l4d2director.inc
@@ -41,7 +41,7 @@
  * 
  * @return 	current tank count
  */
-native L4D2_GetTankCount();
+native int L4D2_GetTankCount();
 
 /**
  * @brief Gets the campaign scores stored in the Versus Director
@@ -50,7 +50,7 @@ native L4D2_GetTankCount();
  * @param scores 		Array to store the campaign scores in
  * @noreturn 				
  */
-native L4D2_GetVersusCampaignScores(scores[2]);
+native void L4D2_GetVersusCampaignScores(int scores[2]);
 
 /**
  * @brief Sets the campaign scores stored in the Versus Director
@@ -59,7 +59,7 @@ native L4D2_GetVersusCampaignScores(scores[2]);
  * @param scores 		Array of campaign scores to set the director's values to.
  * @noreturn 				
  */
-native L4D2_SetVersusCampaignScores(const scores[2]);
+native void L4D2_SetVersusCampaignScores(const int scores[2]);
 
 /**
  * @brief Gets the flow percent for tank spawns for both versus rounds.
@@ -70,7 +70,7 @@ native L4D2_SetVersusCampaignScores(const scores[2]);
  * @param tankFlows	Array to store the Tank Spawn Flow percents in
  * @noreturn 				
  */
-native L4D2_GetVersusTankFlowPercent(Float:tankFlows[2]);
+native void L4D2_GetVersusTankFlowPercent(float tankFlows[2]);
 
 /**
  * @brief Sets the flow percent for tank spawns for both versus rounds.
@@ -81,5 +81,5 @@ native L4D2_GetVersusTankFlowPercent(Float:tankFlows[2]);
  * @param tankFlows	Array of Tank Spawn Flow percents to store in director
  * @noreturn 				
  */
-native L4D2_SetVersusTankFlowPercent(const Float:tankFlows[2]);
+native void L4D2_SetVersusTankFlowPercent(const float tankFlows[2]);
 

--- a/scripting/include/l4d2timers.inc
+++ b/scripting/include/l4d2timers.inc
@@ -64,7 +64,7 @@ enum L4D2IntervalTimer
  * @param timer 		CountdownTimer to reset
  * @noreturn 				
  */
-native L4D2_CTimerReset(L4D2CountdownTimer:timer);
+native void L4D2_CTimerReset(L4D2CountdownTimer timer);
 
 /**
  * @brief Starts a given CountdownTimer with a given duration
@@ -74,7 +74,7 @@ native L4D2_CTimerReset(L4D2CountdownTimer:timer);
  * @param duration		Duration for the timer to use
  * @noreturn 				
  */
-native L4D2_CTimerStart(L4D2CountdownTimer:timer, Float:duration);
+native void L4D2_CTimerStart(L4D2CountdownTimer timer, float duration);
 
 /**
  * @brief Invalidates a given CountdownTimer (Timer essentially does not run)
@@ -83,7 +83,7 @@ native L4D2_CTimerStart(L4D2CountdownTimer:timer, Float:duration);
  * @param timer 		CountdownTimer to Invalidate
  * @noreturn 				
  */
-native L4D2_CTimerInvalidate(L4D2CountdownTimer:timer);
+native void L4D2_CTimerInvalidate(L4D2CountdownTimer timer);
 
 /**
  * @brief Tells if a given CountdownTimer has started
@@ -92,7 +92,7 @@ native L4D2_CTimerInvalidate(L4D2CountdownTimer:timer);
  * @param timer 		CountdownTimer to check
  * @return 				true if timer has started, false if timer is not started/invalid.
  */
-native bool:L4D2_CTimerHasStarted(L4D2CountdownTimer:timer);
+native bool L4D2_CTimerHasStarted(L4D2CountdownTimer timer);
 
 /**
  * @brief Tells if a given CountdownTimer is elapsed
@@ -101,7 +101,7 @@ native bool:L4D2_CTimerHasStarted(L4D2CountdownTimer:timer);
  * @param timer 		CountdownTimer to check
  * @return 				true if timer has elapsed or timer invalid/not started, false otherwise
  */
-native bool:L4D2_CTimerIsElapsed(L4D2CountdownTimer:timer);
+native bool L4D2_CTimerIsElapsed(L4D2CountdownTimer timer);
 
 /**
  * @brief Gets elapsed time of a given CountdownTimer, from the timed it was Start()ed
@@ -110,7 +110,7 @@ native bool:L4D2_CTimerIsElapsed(L4D2CountdownTimer:timer);
  * @param timer 		CountdownTimer to get elapsed time of
  * @return 				Float amount of time since timer started
  */
-native Float:L4D2_CTimerGetElapsedTime(L4D2CountdownTimer:timer);
+native float L4D2_CTimerGetElapsedTime(L4D2CountdownTimer timer);
 
 /**
  * @brief Gets remaining time on a given CountdownTimer
@@ -119,7 +119,7 @@ native Float:L4D2_CTimerGetElapsedTime(L4D2CountdownTimer:timer);
  * @param timer 		CountdownTimer to get remaining time of
  * @return 				Float amount of time remaining on the timer
  */
-native Float:L4D2_CTimerGetRemainingTime(L4D2CountdownTimer:timer);
+native float L4D2_CTimerGetRemainingTime(L4D2CountdownTimer timer);
 
 /**
  * @brief Gets the duration of a given CountdownTimer
@@ -128,7 +128,7 @@ native Float:L4D2_CTimerGetRemainingTime(L4D2CountdownTimer:timer);
  * @param timer 		CountdownTimer to get duration of
  * @return 				0.0 for invalid/not started timers, timer duration otherwise.
  */
-native Float:L4D2_CTimerGetCountdownDuration(L4D2CountdownTimer:timer);
+native float L4D2_CTimerGetCountdownDuration(L4D2CountdownTimer timer);
 
 /*************************************
 	IntervalTimer Natives 
@@ -141,7 +141,7 @@ native Float:L4D2_CTimerGetCountdownDuration(L4D2CountdownTimer:timer);
  * @param timer 		IntervalTimer to start
  * @noreturn 				
  */
-native L4D2_ITimerStart(L4D2IntervalTimer:timer);
+native void L4D2_ITimerStart(L4D2IntervalTimer timer);
 
 /**
  * @brief Invalidates a given IntervalTimer
@@ -150,7 +150,7 @@ native L4D2_ITimerStart(L4D2IntervalTimer:timer);
  * @param timer 		IntervalTimer to Invalidate
  * @noreturn 				
  */
-native L4D2_ITimerInvalidate(L4D2IntervalTimer:timer);
+native void L4D2_ITimerInvalidate(L4D2IntervalTimer timer);
 
 /**
  * @brief Tells whether a given IntervalTimer has started
@@ -159,7 +159,7 @@ native L4D2_ITimerInvalidate(L4D2IntervalTimer:timer);
  * @param timer 		IntervalTimer to check
  * @return 				true if timer is started, false if it is invalid/not started
  */
-native bool:L4D2_ITimerHasStarted(L4D2IntervalTimer:timer);
+native bool L4D2_ITimerHasStarted(L4D2IntervalTimer timer);
 	
 /**
  * @brief Gets the elapsed time of a given IntervalTimer
@@ -168,4 +168,4 @@ native bool:L4D2_ITimerHasStarted(L4D2IntervalTimer:timer);
  * @param timer 		IntervalTimer to get elapsed time of
  * @return				Elapsed time if timer started and valid, 99999.9f otherwise
  */
-native Float:L4D2_ITimerGetElapsedTime(L4D2IntervalTimer:timer);
+native float L4D2_ITimerGetElapsedTime(L4D2IntervalTimer timer);

--- a/scripting/include/l4d2weapons.inc
+++ b/scripting/include/l4d2weapons.inc
@@ -48,7 +48,7 @@ and use something like this with a small timer delay of 0.1 seconds or more (don
 	
 	new weapon = GetPlayerWeaponSlot(client, 0);
 	if (weapon == INVALID_ENT_REFERENCE) return; 
-	decl String:class[56];
+	decl char class[56];
 	GetEdictClassname(weapon, class, sizeof(class));
 	SetEntProp(weapon, Prop_Send, "m_iClip1", L4D2_GetIntWeaponAttribute(class, L4D2IWA_ClipSize));
 */
@@ -100,7 +100,7 @@ enum L4D2FloatMeleeWeaponAttributes
  * @param weaponName 	Weapon to check up on
  * @return 				True if weapon is found, false if not
  */
-native bool:L4D2_IsValidWeapon(const String:weaponName[]);
+native bool L4D2_IsValidWeapon(const char[] weaponName);
 
 /**
  * @brief Read an int-typed attribute for a given weapon from the WeaponInformationDatabase
@@ -110,7 +110,7 @@ native bool:L4D2_IsValidWeapon(const String:weaponName[]);
  * @param attr			Attribute to read from the weapon's info struct
  * @return 				The value read.
  */
-native L4D2_GetIntWeaponAttribute(const String:weaponName[], L4D2IntWeaponAttributes:attr);
+native int L4D2_GetIntWeaponAttribute(const char[] weaponName, L4D2IntWeaponAttributes attr);
 
 /**
  * @brief Read a float-typed attribute for a given weapon from the WeaponInformationDatabase
@@ -120,7 +120,7 @@ native L4D2_GetIntWeaponAttribute(const String:weaponName[], L4D2IntWeaponAttrib
  * @param attr			Attribute to read from the weapon's info struct
  * @return 				The value read.
  */
-native Float:L4D2_GetFloatWeaponAttribute(const String:weaponName[], L4D2FloatWeaponAttributes:attr);
+native float L4D2_GetFloatWeaponAttribute(const char[] weaponName, L4D2FloatWeaponAttributes attr);
 
 /**
  * @brief Set an int-typed attribute for a given weapon from the WeaponInformationDatabase to a given value
@@ -131,7 +131,7 @@ native Float:L4D2_GetFloatWeaponAttribute(const String:weaponName[], L4D2FloatWe
  * @param value			Value to set the attribute to
  * @noreturn
  */
-native L4D2_SetIntWeaponAttribute(const String:weaponName[], L4D2IntWeaponAttributes:attr, value);
+native void L4D2_SetIntWeaponAttribute(const char[] weaponName, L4D2IntWeaponAttributes attr, int value);
 
 /**
  * @brief Set a float-typed attribute for a given weapon from the WeaponInformationDatabase to a given value
@@ -142,7 +142,7 @@ native L4D2_SetIntWeaponAttribute(const String:weaponName[], L4D2IntWeaponAttrib
  * @param value			Value to set the attribute to
  * @noreturn
  */
-native Float:L4D2_SetFloatWeaponAttribute(const String:weaponName[], L4D2FloatWeaponAttributes:attr, Float:value);
+native void L4D2_SetFloatWeaponAttribute(const char[] weaponName, L4D2FloatWeaponAttributes attr, float value);
 
 
 
@@ -155,7 +155,7 @@ native Float:L4D2_SetFloatWeaponAttribute(const String:weaponName[], L4D2FloatWe
  * @param weaponName 	Weapon to lookup index id for
  * @return 				The index id
  */
-native L4D2_GetMeleeWeaponIndex(const String:weaponName[]);
+native int L4D2_GetMeleeWeaponIndex(const char[] weaponName);
 
 /**
  * @brief Read an int-typed attribute for a given id from the Melee Weapon Database
@@ -165,7 +165,7 @@ native L4D2_GetMeleeWeaponIndex(const String:weaponName[]);
  * @param attr			Attribute to read from the weapon's info struct
  * @return 				The value read.
  */
-native L4D2_GetIntMeleeAttribute(id, L4D2IntMeleeWeaponAttributes:attr);
+native int L4D2_GetIntMeleeAttribute(int id, L4D2IntMeleeWeaponAttributes attr);
 
 /**
  * @brief Read a float-typed attribute for a given id from the Melee Weapon Database
@@ -175,7 +175,7 @@ native L4D2_GetIntMeleeAttribute(id, L4D2IntMeleeWeaponAttributes:attr);
  * @param attr			Attribute to read from the weapon's info struct
  * @return 				The value read.
  */
-native Float:L4D2_GetFloatMeleeAttribute(id, L4D2FloatMeleeWeaponAttributes:attr);
+native float L4D2_GetFloatMeleeAttribute(int id, L4D2FloatMeleeWeaponAttributes attr);
 
 /**
  * @brief Read a bool-typed attribute for a given id from the Melee Weapon Database
@@ -185,7 +185,7 @@ native Float:L4D2_GetFloatMeleeAttribute(id, L4D2FloatMeleeWeaponAttributes:attr
  * @param attr			Attribute to read from the weapon's info struct
  * @return 				The value read.
  */
-native bool:L4D2_GetBoolMeleeAttribute(id, L4D2BoolMeleeWeaponAttributes:attr);
+native bool L4D2_GetBoolMeleeAttribute(int id, L4D2BoolMeleeWeaponAttributes attr);
 
 /**
  * @brief Set an int-typed attribute for a given id from the Melee Weapon Database to a given value
@@ -196,7 +196,7 @@ native bool:L4D2_GetBoolMeleeAttribute(id, L4D2BoolMeleeWeaponAttributes:attr);
  * @param value			Value to set the attribute to
  * @noreturn
  */
-native L4D2_SetIntMeleeAttribute(id, L4D2IntMeleeWeaponAttributes:attr, value);
+native void L4D2_SetIntMeleeAttribute(int id, L4D2IntMeleeWeaponAttributes attr, int value);
 
 /**
  * @brief Set a float-typed attribute for a given id from the Melee Weapon Database to a given value
@@ -207,7 +207,7 @@ native L4D2_SetIntMeleeAttribute(id, L4D2IntMeleeWeaponAttributes:attr, value);
  * @param value			Value to set the attribute to
  * @noreturn
  */
-native Float:L4D2_SetFloatMeleeAttribute(id, L4D2FloatMeleeWeaponAttributes:attr, Float:value);
+native void L4D2_SetFloatMeleeAttribute(int id, L4D2FloatMeleeWeaponAttributes attr, float value);
 
 /**
  * @brief Set a bool-typed attribute for a given id from the Melee Weapon Database to a given value
@@ -218,4 +218,4 @@ native Float:L4D2_SetFloatMeleeAttribute(id, L4D2FloatMeleeWeaponAttributes:attr
  * @param value			Value to set the attribute to
  * @noreturn
  */
-native Float:L4D2_SetBoolMeleeAttribute(id, L4D2BoolMeleeWeaponAttributes:attr, bool:value);
+native void L4D2_SetBoolMeleeAttribute(int id, L4D2BoolMeleeWeaponAttributes attr, bool value);

--- a/scripting/include/left4downtown.inc
+++ b/scripting/include/left4downtown.inc
@@ -45,7 +45,7 @@
  * @param qangle	QAngle where tank will be facing
  * @return 		Pl_Handled to block tank from spawning, Pl_Continue otherwise.
  */
-forward Action:L4D_OnSpawnTank(const Float:vector[3], const Float:qangle[3]);
+forward Action L4D_OnSpawnTank(const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Called whenever ZombieManager::SpawnWitch(Vector&,QAngle&) is invoked
@@ -54,7 +54,7 @@ forward Action:L4D_OnSpawnTank(const Float:vector[3], const Float:qangle[3]);
  * @param qangle	QAngle where witch will be facing
  * @return 		Pl_Handled to block witch from spawning, Pl_Continue otherwise.
  */
-forward Action:L4D_OnSpawnWitch(const Float:vector[3], const Float:qangle[3]);
+forward Action L4D_OnSpawnWitch(const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Called whenever ZombieManager::SpawnWitchBride(Vector&,QAngle&) is invoked
@@ -63,7 +63,7 @@ forward Action:L4D_OnSpawnWitch(const Float:vector[3], const Float:qangle[3]);
  * @param qangle	QAngle where witch will be facing
  * @return 		Pl_Handled to block witch from spawning, Pl_Continue otherwise.
  */
-forward Action:L4D_OnSpawnWitchBride(const Float:vector[3], const Float:qangle[3]);
+forward Action L4D_OnSpawnWitchBride(const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Called whenever ZombieManager::SpawnSpecial(ZombieClassType,Vector&,QAngle&) is invoked
@@ -75,7 +75,7 @@ forward Action:L4D_OnSpawnWitchBride(const Float:vector[3], const Float:qangle[3
  * @return 				Pl_Handled to block special from spawning, 
  * 				Pl_Changed to change the zombie class type to spawn, Pl_Continue otherwise.
  */
-forward Action:L4D_OnSpawnSpecial(&zombieClass, const Float:vector[3], const Float:qangle[3]);
+forward Action L4D_OnSpawnSpecial(int &zombieClass, const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Called whenever CTerrorGameRules::ClearTeamScores(bool) is invoked
@@ -85,7 +85,7 @@ forward Action:L4D_OnSpawnSpecial(&zombieClass, const Float:vector[3], const Flo
  * @param newCampaign  if true then this is a new campaign, if false a new chapter
  * @return 		Pl_Handled to block scores from being cleared, Pl_Continue otherwise.
  */
-forward Action:L4D_OnClearTeamScores(bool:newCampaign);
+forward Action L4D_OnClearTeamScores(bool newCampaign);
 
 /**
  * @brief Called whenever CTerrorGameRules::SetCampaignScores(int,int) is invoked
@@ -95,7 +95,7 @@ forward Action:L4D_OnClearTeamScores(bool:newCampaign);
  * @param scoreB  score of logical team B
  * @return 		Pl_Handled to block campaign scores from being set, Pl_Continue otherwise.
  */
-forward Action:L4D_OnSetCampaignScores(&scoreA, &scoreB);
+forward Action L4D_OnSetCampaignScores(int &scoreA, int &scoreB);
 
 /**
  * @brief Called whenever CDirector::OnFirstSurvivorLeftSafeArea is invoked
@@ -106,7 +106,7 @@ forward Action:L4D_OnSetCampaignScores(&scoreA, &scoreB);
  * 
  * @return 		Pl_Handled to block round from being started, Pl_Continue otherwise.
  */
-forward Action:L4D_OnFirstSurvivorLeftSafeArea(client);
+forward Action L4D_OnFirstSurvivorLeftSafeArea(int client);
 
 /**
  * @brief Called whenever CDirector::GetScriptValue(const char*, int) is invoked
@@ -117,7 +117,7 @@ forward Action:L4D_OnFirstSurvivorLeftSafeArea(client);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetScriptValueInt(const String:key[], &retVal);
+forward Action L4D_OnGetScriptValueInt(const char[] key, int &retVal);
 
 /**
  * @brief Called whenever CDirector::GetScriptValue(const char*, float) is invoked
@@ -128,7 +128,7 @@ forward Action:L4D_OnGetScriptValueInt(const String:key[], &retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetScriptValueFloat(const String:key[], &Float:retVal);
+forward Action L4D_OnGetScriptValueFloat(const char[] key, float &retVal);
 
 /**
  * @brief Called whenever CDirector::GetScriptValue(const char*, const char*, char*, int) is invoked
@@ -140,7 +140,7 @@ forward Action:L4D_OnGetScriptValueFloat(const String:key[], &Float:retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetScriptValueString(const String:key[], const String:defaultVal[], String:retVal[128]);
+forward Action L4D_OnGetScriptValueString(const char[] key, const char[] defaultVal, char retVal[128]);
 
 /**
  * @brief Called whenever CTerrorPlayer::OnEnterGhostState(CTerrorPlayer*) is invoked
@@ -148,7 +148,7 @@ forward Action:L4D_OnGetScriptValueString(const String:key[], const String:defau
  * 
  * @param client  the client that has entered ghost mode
  */
-forward L4D_OnEnterGhostState(client);
+forward L4D_OnEnterGhostState(int client);
 
 /**
  * @brief Called whenever ZombieManager::ReplaceTank(CTerrorPlayer *,CTerrorPlayer *) is invoked
@@ -157,7 +157,7 @@ forward L4D_OnEnterGhostState(client);
  * @param CTerrorPlayer	tank the player who was a tank
  * @param CTerrorPlayer	newtank a player who has become a new tank
  */
-forward L4D_OnReplaceTank(tank, newtank);
+forward L4D_OnReplaceTank(int tank, int newtank);
 
 /**
  * @brief Called whenever CDirector::TryOfferingTankBot is invoked
@@ -165,7 +165,7 @@ forward L4D_OnReplaceTank(tank, newtank);
  * 
  * @return 		Pl_Handled to block window from showing and to keep Tank Bot, Pl_Continue otherwise
  */
-forward Action:L4D_OnTryOfferingTankBot(tank_index, &bool:enterStasis);
+forward Action L4D_OnTryOfferingTankBot(int tank_index, bool &enterStasis);
 
 /**
  * @brief Called whenever CDirector::OnMobRushStart(void) is invoked
@@ -175,7 +175,7 @@ forward Action:L4D_OnTryOfferingTankBot(tank_index, &bool:enterStasis);
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D_OnMobRushStart();
+forward Action L4D_OnMobRushStart();
 
 /**
  * @brief Called whenever ZombieManager::SpawnITMob(int) is invoked
@@ -185,7 +185,7 @@ forward Action:L4D_OnMobRushStart();
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D_OnSpawnITMob(&amount);
+forward Action L4D_OnSpawnITMob(int &amount);
 
 /**
  * @brief Called whenever ZombieManager::SpawnMob(int) is invoked
@@ -197,7 +197,7 @@ forward Action:L4D_OnSpawnITMob(&amount);
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D_OnSpawnMob(&amount);
+forward Action L4D_OnSpawnMob(int &amount);
 
 /**
  * @brief Called whenever CTerrorPlayer::OnShovedBySurvivor(CTerrorPlayer, Vector&) is invoked
@@ -209,7 +209,7 @@ forward Action:L4D_OnSpawnMob(&amount);
  *
  * @return 		Pl_Handled to block melee effect (staggering), Pl_Continue otherwise.
  */
-forward Action:L4D_OnShovedBySurvivor(client, victim, const Float:vector[3]);
+forward Action L4D_OnShovedBySurvivor(int client, int victim, const float vecDirection[3]);
 
 /**
  * @brief Called whenever CTerrorPlayer::GetCrouchTopSpeed() is invoked
@@ -219,7 +219,7 @@ forward Action:L4D_OnShovedBySurvivor(client, victim, const Float:vector[3]);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetCrouchTopSpeed(target, &Float:retVal);
+forward Action L4D_OnGetCrouchTopSpeed(int target, float &retVal);
 
 /**
  * @brief Called whenever CTerrorPlayer::GetRunTopSpeed() is invoked
@@ -229,7 +229,7 @@ forward Action:L4D_OnGetCrouchTopSpeed(target, &Float:retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetRunTopSpeed(target, &Float:retVal);
+forward Action L4D_OnGetRunTopSpeed(int target, float &retVal);
 
 /**
  * @brief Called whenever CTerrorPlayer::GetWalkTopSpeed() is invoked
@@ -239,7 +239,7 @@ forward Action:L4D_OnGetRunTopSpeed(target, &Float:retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetWalkTopSpeed(target, &Float:retVal);
+forward Action L4D_OnGetWalkTopSpeed(int target, float &retVal);
 
 /**
  * @brief Called whenever CTerrorGameRules::HasConfigurableDifficultySetting() is invoked
@@ -249,7 +249,7 @@ forward Action:L4D_OnGetWalkTopSpeed(target, &Float:retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnHasConfigurableDifficulty(&retVal);
+forward Action L4D_OnHasConfigurableDifficulty(int &retVal);
 
 /**
  * @brief Called whenever CTerrorGameRules::GetSurvivorSet(void) is invoked
@@ -258,7 +258,7 @@ forward Action:L4D_OnHasConfigurableDifficulty(&retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnGetSurvivorSet(&retVal);
+forward Action L4D_OnGetSurvivorSet(int &retVal);
 
 /**
  * @brief Called whenever CTerrorGameRules::FastGetSurvivorSet(void) is invoked
@@ -267,7 +267,7 @@ forward Action:L4D_OnGetSurvivorSet(&retVal);
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D_OnFastGetSurvivorSet(&retVal);
+forward Action L4D_OnFastGetSurvivorSet(int &retVal);
 
 /**
  * @brief Called whenever CDirectorVersusMode::GetMissionVersusBossSpawning() is invoked
@@ -280,7 +280,7 @@ forward Action:L4D_OnFastGetSurvivorSet(&retVal);
  * 
  * @return 		Pl_Handled to block reading map data, Pl_Changed to use overwritten values from plugin, Pl_Continue to continue to read from mission data.
  */
-forward Action:L4D_OnGetMissionVSBossSpawning(&Float:spawn_pos_min, &Float:spawn_pos_max, &Float:tank_chance, &Float:witch_chance);
+forward Action L4D_OnGetMissionVSBossSpawning(float &spawn_pos_min, float &spawn_pos_max, float &tank_chance, float &witch_chance);
 
 /**
  * @brief Called whenever CThrow::ActivateAbility(void) is invoked
@@ -291,7 +291,7 @@ forward Action:L4D_OnGetMissionVSBossSpawning(&Float:spawn_pos_min, &Float:spawn
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D_OnCThrowActivate(ability);
+forward Action L4D_OnCThrowActivate(int ability);
 
 /**
  * @brief Called whenever InfectedShoved::OnShoved(Infected *, CBaseEntity *) is invoked
@@ -299,7 +299,7 @@ forward Action:L4D_OnCThrowActivate(ability);
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D_OnInfectedShoved(infected, entity);
+forward Action L4D_OnInfectedShoved(int infected, int entity);
 
 /**
  * @brief Called whenever CTerrorMeleeWeapon::StartMeleeSwing(CTerrorPlayer *, bool) is invoked
@@ -308,7 +308,7 @@ forward Action:L4D_OnInfectedShoved(infected, entity);
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D_OnStartMeleeSwing(client, bool:boolean);
+forward Action L4D_OnStartMeleeSwing(int client, bool boolean);
 
 /**
  * @brief Called whenever CDirectorScriptedEventManager::SendInRescueVehicle(void) is invoked
@@ -317,7 +317,7 @@ forward Action:L4D_OnStartMeleeSwing(client, bool:boolean);
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnSendInRescueVehicle();
+forward Action L4D2_OnSendInRescueVehicle();
 
 /**
  * @brief Called whenever CDirectorScriptedEventManager::ChangeFinaleStage is invoked
@@ -328,7 +328,7 @@ forward Action:L4D2_OnSendInRescueVehicle();
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnChangeFinaleStage(&finaleType, const String:arg[]);
+forward Action L4D2_OnChangeFinaleStage(int &finaleType, const char[] arg);
 
 /**
  * @brief Called whenever CDirectorVersusMode::EndVersusModeRound(bool) is invoked
@@ -339,7 +339,7 @@ forward Action:L4D2_OnChangeFinaleStage(&finaleType, const String:arg[]);
  * 
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnEndVersusModeRound(bool:countSurvivors);
+forward Action L4D2_OnEndVersusModeRound(bool countSurvivors);
 
 /**
  * @brief Called after CDirectorVersusMode::EndVersusModeRound(bool)
@@ -360,7 +360,7 @@ forward L4D2_OnEndVersusModeRound_Post();
  * 
  * @return 		Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D2_OnSelectTankAttack(client, &sequence);
+forward Action L4D2_OnSelectTankAttack(int client, int &sequence);
 
 /**
  * @brief Called when CTerrorPlayer::OnRevived(void) is invoked
@@ -370,7 +370,7 @@ forward Action:L4D2_OnSelectTankAttack(client, &sequence);
  *
  * @noreturn Pl_Handled to override return value, Pl_Continue otherwise.
  */
-forward Action:L4D2_OnRevived(client);
+forward Action L4D2_OnRevived(int client);
 
 /**
  * @brief Called when SurvivorBot::UseHealingItems(Action<SurvivorBot> *) is invoked
@@ -380,7 +380,7 @@ forward Action:L4D2_OnRevived(client);
  *
  * @noreturn Pl_Handled to block, Pl_Continue otherwise.
  */
-forward Action:L4D2_OnUseHealingItems(client);
+forward Action L4D2_OnUseHealingItems(int client);
 
 /**
  * @brief Called after SurvivorBot::FindScavengeItem(Action<SurvivorBot> *) is invoked
@@ -391,7 +391,7 @@ forward Action:L4D2_OnUseHealingItems(client);
  *
  * @noreturn Pl_Handled to block, Pl_Continue otherwise.
  */
-forward Action:L4D2_OnFindScavengeItem(client, item);
+forward Action L4D2_OnFindScavengeItem(int client, int item);
 
 /**
  * @brief Called whenever CBasePlayer::WaterMove() is invoked
@@ -401,7 +401,7 @@ forward Action:L4D2_OnFindScavengeItem(client, item);
  *
  * @noreturn
  */
-forward L4D2_OnWaterMove(client);
+forward L4D2_OnWaterMove(int client);
 
 /**
  * @brief Called whenever CTerrorPlayer::OnStaggered(CBaseEntity *, Vector const *) is invoked
@@ -412,7 +412,7 @@ forward L4D2_OnWaterMove(client);
  *
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnStagger(target, source);
+forward Action L4D2_OnStagger(int target, int source);
 
 /**
  * @brief Called whenever CTerrorWeapon::OnHit(CGameTrace &, Vector  const&, bool) is invoked
@@ -426,7 +426,7 @@ forward Action:L4D2_OnStagger(target, source);
  *
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnEntityShoved(client, entity, weapon, Float:vector[3], bool:bIsHighPounce);
+forward Action L4D2_OnEntityShoved(int client, int entity, int weapon, float vector[3], bool bIsHighPounce);
 
 /**
  * @brief Called when the client's material system is expecting instructions from the server in regards to addons
@@ -436,7 +436,7 @@ forward Action:L4D2_OnEntityShoved(client, entity, weapon, Float:vector[3], bool
  *
  * @return      Pl_Handled to let the client through with addons, Pl_Continue otherwise.
  */
-forward Action:L4D2_OnClientDisableAddons(const String:SteamID[]);
+forward Action L4D2_OnClientDisableAddons(const char[] SteamID[]);
 
 /**
  * @brief Called whenever CInferno::Spread(Vector const&) is invoked (only for spitters -- ignores fire)
@@ -449,7 +449,7 @@ forward Action:L4D2_OnClientDisableAddons(const String:SteamID[]);
  *
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnSpitSpread(spitter, projectile, &Float:x, &Float:y, &Float:z);
+forward Action L4D2_OnSpitSpread(int spitter, int projectile, float &x, float &y, float &z);
 
 /**
  * @brief Called whenever CTerrorPlayer::OnShovedByPounceLanding(CTerrorPlayer*) is invoked
@@ -459,7 +459,7 @@ forward Action:L4D2_OnSpitSpread(spitter, projectile, &Float:x, &Float:y, &Float
  *
  * @return 		Pl_Handled to block, Pl_Continue otherwise
  */
-forward Action:L4D2_OnPounceOrLeapStumble(victim, attacker);
+forward Action L4D2_OnPounceOrLeapStumble(int victim, int attacker);
 
 /**
  * @brief Get the current campaign scores stored in the Director
@@ -473,7 +473,7 @@ forward Action:L4D2_OnPounceOrLeapStumble(victim, attacker);
  * @return 		1 always
  */
 #pragma deprecated Use GetTeamScore and OnClearTeamScores instead
-native L4D_GetCampaignScores(&scoreA, &scoreB);
+native int L4D_GetCampaignScores(int &scoreA, int &scoreB);
 
 /**
  * @brief Get the team scores for the current map
@@ -489,14 +489,14 @@ native L4D_GetCampaignScores(&scoreA, &scoreB);
  *                      or -1 if the team hasn't played the round yet,
  *                or the team's campaign score if campaign_score = true
  */
-native L4D_GetTeamScore(logical_team, campaign_score=false);
+native int L4D_GetTeamScore(int logical_team, bool campaign_score=false);
 
 /**
  * @brief Restarts the setup timer (when in scavenge mode)
  * @remarks If game has already started, the setup timer will show,
  *           but it still won't go back into setup.
  */
-native L4D_ScavengeBeginRoundSetupTime();
+native void L4D_ScavengeBeginRoundSetupTime();
 
 /**
  * @brief Restarts the round, switching the map if necessary
@@ -505,14 +505,14 @@ native L4D_ScavengeBeginRoundSetupTime();
  * @param map  the mapname it should go to after the round restarts
  * @return     1 always
  */
-native L4D_RestartScenarioFromVote(const String:map[]);
+native void L4D_RestartScenarioFromVote(const char[] map);
 
 /**
  * @brief Removes lobby reservation from a server
  * @remarks Sets the reservation cookie to 0,
  *           it is safe to call this even if it's unreserved.
  */
-native L4D_LobbyUnreserve();
+native void L4D_LobbyUnreserve();
 
 /**
  * @brief Checks if the server is currently reserved for a lobby
@@ -524,7 +524,7 @@ native L4D_LobbyUnreserve();
  * @return     true if reserved, false if not reserved
  */
 #pragma deprecated This will always return false on L4D2 or on Linux.
-native bool:L4D_LobbyIsReserved();
+native bool L4D_LobbyIsReserved();
 
 /**
  * @brief Gets the max versus completion score for the map
@@ -534,7 +534,7 @@ native bool:L4D_LobbyIsReserved();
  *
  * @return     The map's max completion distance (map distance score)
  */
-native L4D_GetVersusMaxCompletionScore();
+native int L4D_GetVersusMaxCompletionScore();
 
 /**
  * @brief Sets the max versus completion score for the map
@@ -543,14 +543,14 @@ native L4D_GetVersusMaxCompletionScore();
  *
  * @param	score	The versus max completion score to set for the round
  */
-native L4D_SetVersusMaxCompletionScore(score);
+native void L4D_SetVersusMaxCompletionScore(int score);
 
 /**
  * @brief Tells if the Mission (map) is the final map of the campaign
  *
  * @return		true if the map is the last map of the campaign (finale)
  */
-native bool:L4D_IsMissionFinalMap();
+native bool L4D_IsMissionFinalMap();
 
 /**
  * @brief Resets the natural mob (horde) timer
@@ -558,7 +558,7 @@ native bool:L4D_IsMissionFinalMap();
  *
  * @noreturn
  */
-native L4D_ResetMobTimer();
+native void L4D_ResetMobTimer();
 
 /**
  * @brief Notifies the CGameRulesProxy that the game state has been changed
@@ -567,7 +567,7 @@ native L4D_ResetMobTimer();
  *
  * @noreturn
  */
-native L4D_NotifyNetworkStateChanged();
+native void L4D_NotifyNetworkStateChanged();
 
 /**
  * @brief Trigger's a target player's stagger behavior 
@@ -575,10 +575,10 @@ native L4D_NotifyNetworkStateChanged();
  * 
  * @param target 		Player to stagger
  * @param source_ent	Source of the stagger (another player, etc)
- * @param source_vector Source location of the stagger. If NULL_VECTOR, origins of source_ent is used.
+ * @param vecSource 	Source location of the stagger. If NULL_VECTOR, origins of source_ent is used.
  * @noreturn 				
  */
-native L4D_StaggerPlayer(target, source_ent, Float:source_vector[3]);
+native void L4D_StaggerPlayer(int target, int source_ent, float vecSource[3]);
 
 /**
  * @brief Get the time remaining before the next director horde. 
@@ -587,7 +587,7 @@ native L4D_StaggerPlayer(target, source_ent, Float:source_vector[3]);
  * @return 	Time remaining before next director horde
  */
 #pragma deprecated Use L4D2_CTimerGetRemainingTime(L4D2CT_MobSpawnTimer)
-native Float:L4D_GetMobSpawnTimerRemaining();
+native float L4D_GetMobSpawnTimerRemaining();
 
 /**
  * @brief Get the duration the horde timer was set to after the last horde
@@ -596,7 +596,7 @@ native Float:L4D_GetMobSpawnTimerRemaining();
  * @return 	Total time from last horde to next horde.
  */
 #pragma deprecated Use L4D2_CTimerGetCountdownDuration(L4D2CT_MobSpawnTimer)
-native Float:L4D_GetMobSpawnTimerDuration();
+native float L4D_GetMobSpawnTimerDuration();
 
 /**
  * @brief Get the remaining spawn time for an SI
@@ -604,7 +604,7 @@ native Float:L4D_GetMobSpawnTimerDuration();
  * 
  * @return 	Time (seconds) until the SI will spawn.
  */
-native Float:L4D_GetPlayerSpawnTime(player);
+native float L4D_GetPlayerSpawnTime(int player);
 
 /**
  * @brief Calls CDirectorScriptedEventManager::SendInRescueVehicle(void)
@@ -613,7 +613,7 @@ native Float:L4D_GetPlayerSpawnTime(player);
  * 
  * @noreturn
  */
-native L4D2_SendInRescueVehicle();
+native void L4D2_SendInRescueVehicle();
 
 /**
  * @brief Calls ZombieManager::ReplaceTank(CTerrorPlayer *,CTerrorPlayer *)
@@ -621,7 +621,7 @@ native L4D2_SendInRescueVehicle();
  * @param tank	the player who was a tank
  * @param newtank	a player who has become a new tank
  */
-native L4D_ReplaceTank(tank, newtank);
+native void L4D_ReplaceTank(int tank, int newtank);
 
 /**
  * @brief Calls CDirectorScriptedEventManager::ChangeFinaleStage(CDirectorScriptedEventManager::FinaleStageType,char  const*)
@@ -633,7 +633,7 @@ native L4D_ReplaceTank(tank, newtank);
  *
  * @noreturn
  */
-native L4D2_ChangeFinaleStage(finaleType, const String:arg[]);
+native void L4D2_ChangeFinaleStage(int finaleType, const char[] arg);
 
 /**
  * @brief Calls ZombieManager::SpawnTank(Vector&,QAngle&)
@@ -642,7 +642,7 @@ native L4D2_ChangeFinaleStage(finaleType, const String:arg[]);
  * @param qangle	QAngle where the tank will be facing
  * @return 			Entity index of the spawned tank
  */
-native L4D2_SpawnTank(const Float:vector[3], const Float:qangle[3]);
+native int L4D2_SpawnTank(const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Calls ZombieManager::SpawnSpecial(ZombieClassType,Vector&,QAngle&)
@@ -652,7 +652,7 @@ native L4D2_SpawnTank(const Float:vector[3], const Float:qangle[3]);
  * @param qangle	QAngle where the SI will be facing
  * @return 			Entity index of the spawned SI
  */
-native L4D2_SpawnSpecial(zombieClass, const Float:vector[3], const Float:qangle[3]);
+native int L4D2_SpawnSpecial(int zombieClass, const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Calls ZombieManager::SpawnWitch(Vector&,QAngle&)
@@ -661,7 +661,7 @@ native L4D2_SpawnSpecial(zombieClass, const Float:vector[3], const Float:qangle[
  * @param qangle	QAngle where the witch will be facing
  * @return 			Entity index of the spawned witch
  */
-native L4D2_SpawnWitch(const Float:vector[3], const Float:qangle[3]);
+native int L4D2_SpawnWitch(const float vecOrigin[3], const float vecAngles[3]);
 
 /**
  * @brief Calls ZombieManager::SpawnWitchBride(Vector&,QAngle&)
@@ -670,13 +670,13 @@ native L4D2_SpawnWitch(const Float:vector[3], const Float:qangle[3]);
  * @param qangle	QAngle where the witch bride will be facing
  * @return 			Entity index of the spawned witch bride
  */
-native L4D2_SpawnWitchBride(const Float:vector[3], const Float:qangle[3]);
+native int L4D2_SpawnWitchBride(const float vecOrigin[3], const float vecAngles[3]);
 
 /*
 Makes the extension required by the plugins, undefine REQUIRE_EXTENSIONS
 if you want to use it optionally before including this .inc file
 */
-public Extension:__ext_left4downtown = 
+public Extension __ext_left4downtown = 
 {
 	name = "Left 4 Downtown",
 	file = "left4downtown.ext",

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -40,8 +40,8 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"Left 4 Downtown 2"
 #define SMEXT_CONF_DESCRIPTION	"Competitive framework support extension for L4D2"
-#define SMEXT_CONF_VERSION		"0.6.1"
-#define SMEXT_CONF_AUTHOR		"Downtown1, ProdigySim, Visor, Accelerator; minor contrib.: XBetaAlpha, AtomicStryker, $atanic $pirit"
+#define SMEXT_CONF_VERSION		"0.6.2"
+#define SMEXT_CONF_AUTHOR		"Downtown1, ProdigySim, Visor, Accelerator; minor contrib.: XBetaAlpha, AtomicStryker, $atanic $pirit, xerox8521"
 #define SMEXT_CONF_URL			"https://github.com/Accelerator74/Left4Downtown2"
 #define SMEXT_CONF_LOGTAG		"LEFT4DOWNTOWN"
 #define SMEXT_CONF_LICENSE		"GPLv3"


### PR DESCRIPTION
I've added a new forward **L4D2_OnChooseVictim** which is called by each special infected (exception is the witch due to her not being a player but rather just an npc) to determine its current target it should attack.
You could with it for example replicate the old L4D1 tank behaviour.

Also updated the includes to the sourcemod transitional syntax. Although the function is easy to find in the windows binary it has not been tested on windows.